### PR TITLE
Added context classes to sidebars and menus

### DIFF
--- a/functions/attr.php
+++ b/functions/attr.php
@@ -186,13 +186,12 @@ function hybrid_attr_content( $attr ) {
  */
 function hybrid_attr_sidebar( $attr, $context ) {
 
-	if ( !empty( $context ) )
-		$attr['id'] = "sidebar-{$context}";
-
-	$attr['class']     = 'sidebar';
-	$attr['role']      = 'complementary';
+	$attr['class'] = 'sidebar';
+	$attr['role']  = 'complementary';
 
 	if ( !empty( $context ) ) {
+		$attr['id']     = "sidebar-{$context}";
+		$attr['class'] .= " sidebar-{$context}";
 
 		$sidebar_name = hybrid_get_sidebar_name( $context );
 
@@ -219,13 +218,12 @@ function hybrid_attr_sidebar( $attr, $context ) {
  */
 function hybrid_attr_menu( $attr, $context ) {
 
-	if ( !empty( $context ) )
-		$attr['id'] = "menu-{$context}";
-
 	$attr['class']      = 'menu';
 	$attr['role']       = 'navigation';
 
 	if ( !empty( $context ) ) {
+		$attr['id']     = "menu-{$context}";
+		$attr['class'] .= " menu-{$context}";
 
 		$menu_name = hybrid_get_menu_location_name( $context );
 


### PR DESCRIPTION
Having these additional classes can be extremely helpful when styling different elements. If you don’t use IDs in your CSS, there’s currently no straightforward way to do this.

If there's anything about the formatting you don't like, please let me know and I'll update the PR.