### PR TITLE
Fix PHP warning in body_class on archive pages

### DIFF
--- a/functions/context.php
+++ b/functions/context.php
@@ -71,8 +71,22 @@ function hybrid_get_context() {
 
 		/* Post type archives. */
 		if ( is_post_type_archive() ) {
-			$post_type = get_post_type_object( get_query_var( 'post_type' ) );
-			$hybrid->context[] = "archive-{$post_type->name}";
+			/**
+			 * The query var 'post_type' can be an array but the function
+			 * get_post_type_object() only accepts strings (single post type)
+			 *
+			 * @see  http://codex.wordpress.org/Class_Reference/WP_Query#Type_Parameters
+			 */
+			$queried_post_types = get_query_var( 'post_type' );
+
+			if ( ! is_array( $queried_post_types ) ) {
+				$queried_post_types = array( $queried_post_types );
+			}
+
+			foreach ( $queried_post_types as $post_type_key ) {
+				$post_type = get_post_type_object( $post_type_key );
+				$hybrid->context[] = "archive-{$post_type->name}";
+			}
 		}
 
 		/* Taxonomy archives. */


### PR DESCRIPTION
In custom WP_Query calls we can specify an array of post-types to query. When an array of post-types is specified then the body_class() function fails: Hybrid did expect the post_type parameter of the WP_Query to be a string always, though it can be an array.

This PR fixes the issue