### PR TITLE
Fix for w3 validator

### DIFF
--- a/inc/filters.php
+++ b/inc/filters.php
@@ -165,7 +165,7 @@ function hybrid_get_comment_author_url_link( $link ) {
  * @return string
  */
 function hybrid_comment_reply_link_filter( $link ) {
-	return preg_replace( '/(<a\s)/i', '$1itemprop="replyToUrl"', $link );
+	return preg_replace( '/(<a\s)/i', '$1itemprop="replyToUrl" ', $link );
 }
 
 /**


### PR DESCRIPTION
On a page with comments, validator complains about:
"No space between attributes"
<a itemprop="replyToUrl"class='comment-reply-link' href='/about/page-with-com…

btw I'm kinda new to github so I hope I'm doing this correctly.