### PR TITLE
Fix class filter

### DIFF
--- a/src/attr/class-attr.php
+++ b/src/attr/class-attr.php
@@ -205,9 +205,8 @@ class Attr implements Attributes {
 
 		if ( isset( $this->attr['class'] ) && has_filter( $hook ) ) {
 
-			$this->attr[ $name ] = join( ' ', array_unique(
-				apply_filters( $hook, explode( ' ', $value ), $this->context )
-			) );
+			$classes             = apply_filters( $hook, explode( ' ', $this->attr['class'] ), $this->context );
+			$this->attr['class'] = join( ' ', array_unique( $classes ) );
 		}
 
 		return $this->attr;


### PR DESCRIPTION
I was getting a `$value not defined` error and indeed the $value is never defined in that method. I also did not understand the `$this->attr[ $name ]` and figure you probably meant `$this->attr['class']`.

After this change the class filter works as expected.